### PR TITLE
Fix TF-13-19 OFF command to make FSSA-230V work

### DIFF
--- a/lib/definitions/eep/TF-13/TF-13-19.json
+++ b/lib/definitions/eep/TF-13/TF-13-19.json
@@ -20,8 +20,6 @@
                 {
                     "data": "Command ID",
                     "shortcut": "CMD",
-                    "bitoffs": "0",
-                    "bitsize": "3",
                     "iobroker": {
                         "role": "state",
                         "type": "number",
@@ -29,14 +27,21 @@
                         "write": true,
                         "states": "0:OFF; 1:ON;"
                     },
-                    "value": 3
+                    "value": 0
+                },
+                {
+                    "data": "fixed parameter",
+                    "description": "OFF",
+                    "bitoffs": "0",
+                    "bitsize": "3",
+                    "value": 0
                 },
                 {
                     "data": "fixed parameter",
                     "description": "OFF",
                     "bitoffs": "3",
                     "bitsize": "1",
-                    "value": 0
+                    "value": 1
                 }
             ]
         },


### PR DESCRIPTION
EEP send A0=ON and AI=OFF. AI must have DB0.4 bit (pressed) set.