### PR TITLE
Fix FL62NP-230V teachin-telegram

### DIFF
--- a/lib/definitions/eltako.js
+++ b/lib/definitions/eltako.js
@@ -24,7 +24,7 @@ const mscTelegrams = {
 		'fwversion': 'V0101',
 		'id': 1101
 	},
-	'0000042f': {
+	'0000042F': {
 		'name': 'fl62np-230v',
 		'fwversion': 'V0101',
 		'id': 1101
@@ -419,18 +419,6 @@ const mscTelegrams = {
 		'name': 'tf61l-230v',
 		'fwversion': 'V0213',
 		'id': 1043
-	},
-
-	//TF62L-230V
-	'0000042E': {
-		'name': 'tf62l-230v',
-		'fwversion': 'V0101',
-		'id': 1070
-	},
-	'0000042F': {
-		'name': 'tf62l-230v',
-		'fwversion': 'V0101',
-		'id': 1071
 	},
 
 	//TF61R-230V


### PR DESCRIPTION
Device TF62L does not exist. TF62L teachin telegram collides with a teachin telegram of an FL62NP. Quick solution: remove the TF62L devices.

If various devices could have the same teachin, then the switch over all Eltako devices in addEltakoDevice():

switch(eltakoDevices[devTelegram].name) {

must be changed in a way that only the teachin's of the device which is going to be auto-created are considered.