### PR TITLE
Print a log to easier detect teachin telegram problems

### DIFF
--- a/lib/tools/Packet_handler.js
+++ b/lib/tools/Packet_handler.js
@@ -1584,6 +1584,9 @@ async function addEltakoDevice(_this, baseID, offset) {
 
 			break;
 		}
+                default: {
+                        _this.adapter.log.info(`Autocreate of Eltako Device "${eltakoDevices[devTelegram].name}" not yet implemented.`);
+                }
 	}
 }
 


### PR DESCRIPTION
Print a log for teachin telegram problems and/or missing device definitions for autocreate.