### PR TITLE
Add new FD62NPN-230V teachin telegram

### DIFF
--- a/lib/definitions/eltako.js
+++ b/lib/definitions/eltako.js
@@ -55,6 +55,12 @@ const mscTelegrams = {
 		'fwversion': 'V0101',
 		'id': 1102
 	},
+	'0000042A': {
+		'name': 'fd62npn-230v',
+		'fwversion': 'V0101',
+		'id': 1102
+	},
+
 
 	//FD62NP-230V
 	'0000045E': {
@@ -567,18 +573,6 @@ const mscTelegrams = {
 		'name': 'tf-tax5l',
 		'fwversion': 'V0101',
 		'id': 1009
-	},
-
-	//TFD62
-	'0000042A': {
-		'name': 'tfd62',
-		'fwversion': 'V0101',
-		'id': 1066
-	},
-	'0000042B': {
-		'name': 'tfd62',
-		'fwversion': 'V0101',
-		'id': 1067
 	},
 
 	//TFJ62


### PR DESCRIPTION
Once again found a teachin telegram collision. One of my FD62NPN uses 042A as the non existing TFD62 device from eltako.js.