### PR TITLE
D2-01-08 Switch all channels instead of channel 0

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -3,6 +3,7 @@ name: Test and Release
 # Run this job on all pushes and pull requests
 # as well as tags with a semantic version
 on:
+  workflow_dispatch:
   push:
     branches:
       - "main"

--- a/lib/definitions/eep/D2-01/D2-01-08.json
+++ b/lib/definitions/eep/D2-01/D2-01-08.json
@@ -244,7 +244,7 @@
           "description": "dummy byte",
           "bitoffs": "11",
           "bitsize": "5",
-          "value": 0
+          "value": 30
         },
         {
           "data": "fixed parameter",
@@ -284,7 +284,7 @@
           "description": "dummy byte",
           "bitoffs": "11",
           "bitsize": "5",
-          "value": 0
+          "value": 30
         },
         {
           "data": "fixed parameter",
@@ -411,7 +411,7 @@
           "description": "I/O channel",
           "bitoffs": "11",
           "bitsize": "5",
-          "value": 0
+          "value": 30
         }
       ]
     },


### PR DESCRIPTION
I have a PEHA 452 FU-EBI o.T., which is a dual-channel switch where each channel has it's own address (actually 2, one for VLD and one for 4BS).
According to the documentation, it used D2-01-08, just like the "d_4511_fuebim_st", so I tried adding PEHA 452 FU-EBI oT using the 'd_4511_fuebim_st' device. 
Using the UTE, the device is successfully added to ioBroker.

Although, the 452 FU-EBI o.t. uses two different VLD addresses, one for each channel, the IO Channels must be set to either 0 or 1 dependent on the channel you're sending, although there is only one channel available at that VLD address.

This pull request fixes this behaviour, by using 'all channels' instead of fixed channel 0. 
If I understand this https://tools.enocean-alliance.org/EEPViewer/profiles/D2/01/08/D2-01-08.pdf correctly, this profile should be used for single channel switches, so selecting all should not break anything.

I've tested my patch on my installation and fixes the problem that one of the channels isn't switching when requested.

(p.s. ideally, a new device is added for the PEHA 452 FU-EBI ot using this D2-01-08 profile as well)
